### PR TITLE
Move Window.get_size into WindowGLFW implementation

### DIFF
--- a/src/window_glfw.rs
+++ b/src/window_glfw.rs
@@ -168,6 +168,11 @@ impl Window for WindowGLFW {
         (w as u32, h as u32)
     }
 
+    fn get_size(&self) -> (u32, u32) {
+        let (w, h) = self.window.get_size();
+        (w as u32, h as u32)
+    }
+
     fn should_close(&self) -> bool {
         self.window.should_close()
     }


### PR DESCRIPTION
Depending on a default trait implementation was insufficient as the trait used the size the window was constructed with, which is wrong if the window has ever changed size.
