### PR TITLE
Add Gamepad (Joystick) Support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,45 +2,48 @@
 
 //! A GLFW window back-end for the Piston game engine.
 
-extern crate glfw;
 extern crate gl;
+extern crate glfw;
 extern crate input;
-extern crate window;
 extern crate shader_version;
+extern crate window;
 
 // External crates.
-use std::sync::mpsc::Receiver;
-use std::time::Duration;
+use glfw::{Context, Joystick, JoystickId};
+use input::{
+    keyboard, Button, ButtonArgs, ButtonState, CloseArgs, ControllerAxisArgs, ControllerButton,
+    Event, FileDrag, Input, Motion, MouseButton, ResizeArgs,
+};
 use std::collections::VecDeque;
 use std::error::Error;
-use glfw::Context;
-use input::{
-    keyboard,
-    ButtonArgs,
-    ButtonState,
-    CloseArgs,
-    Event,
-    MouseButton,
-    Button,
-    Input,
-    Motion,
-    ResizeArgs,
-    FileDrag,
-};
+use std::time::Duration;
+use std::{collections::HashMap, sync::mpsc::Receiver};
 use window::{
-    BuildFromWindowSettings,
-    Window,
-    AdvancedWindow,
-    OpenGLWindow,
-    ProcAddress,
-    WindowSettings,
-    Size,
-    Position,
-    Api,
-    UnsupportedGraphicsApiError,
+    AdvancedWindow, Api, BuildFromWindowSettings, OpenGLWindow, Position, ProcAddress, Size,
+    UnsupportedGraphicsApiError, Window, WindowSettings,
 };
 
 pub use shader_version::OpenGL;
+
+// list of joysticks to check
+const JOYSTICKS: [JoystickId; 16] = [
+    JoystickId::Joystick1,
+    JoystickId::Joystick2,
+    JoystickId::Joystick3,
+    JoystickId::Joystick4,
+    JoystickId::Joystick5,
+    JoystickId::Joystick6,
+    JoystickId::Joystick7,
+    JoystickId::Joystick8,
+    JoystickId::Joystick9,
+    JoystickId::Joystick10,
+    JoystickId::Joystick11,
+    JoystickId::Joystick12,
+    JoystickId::Joystick13,
+    JoystickId::Joystick14,
+    JoystickId::Joystick15,
+    JoystickId::Joystick16,
+];
 
 /// Contains stuff for game window.
 pub struct GlfwWindow {
@@ -57,25 +60,41 @@ pub struct GlfwWindow {
     title: String,
     exit_on_esc: bool,
     automatic_close: bool,
+
+    /// ignore controller axis inputs below this threshold
+    pub joystick_deadzone: f64,
+    joysticks: Vec<JoystickHelper>,
 }
 
 impl GlfwWindow {
     /// Create a new game window from an existing GLFW window.
-    pub fn from_pieces(mut win: glfw::Window, glfw: glfw::Glfw,
-                       events: Receiver<(f64, glfw::WindowEvent)>,
-                       exit_on_esc: bool) -> GlfwWindow {
+    pub fn from_pieces(
+        mut win: glfw::Window,
+        glfw: glfw::Glfw,
+        events: Receiver<(f64, glfw::WindowEvent)>,
+        exit_on_esc: bool,
+    ) -> GlfwWindow {
         win.set_all_polling(true);
         win.make_current();
         let title = "<unknown window title, created from_pieces>";
+
+        // setup joysticks
+        let mut joysticks = Vec::new();
+        for i in JOYSTICKS {
+            joysticks.push(JoystickHelper::new(glfw.get_joystick(i)));
+        }
+
         GlfwWindow {
+            joysticks,
             window: win,
-            events: events,
-            glfw: glfw,
-            exit_on_esc: exit_on_esc,
+            events,
+            glfw,
+            exit_on_esc,
             event_queue: VecDeque::new(),
             last_mouse_pos: None,
             title: title.to_string(),
             automatic_close: true,
+            joystick_deadzone: 0.0,
         }
     }
 
@@ -86,37 +105,49 @@ impl GlfwWindow {
         // Initialize GLFW.
         let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS)?;
 
-        let api = settings.get_maybe_graphics_api().unwrap_or(Api::opengl(3, 2));
+        let api = settings
+            .get_maybe_graphics_api()
+            .unwrap_or(Api::opengl(3, 2));
         if api.api != "OpenGL" {
             return Err(UnsupportedGraphicsApiError {
                 found: api.api,
-                expected: vec!["OpenGL".into()]
-            }.into());
+                expected: vec!["OpenGL".into()],
+            }
+            .into());
         };
 
         // Make sure we have the right GL version.
         glfw.window_hint(glfw::WindowHint::ContextVersion(api.major, api.minor));
         glfw.window_hint(glfw::WindowHint::Resizable(settings.get_resizable()));
         glfw.window_hint(glfw::WindowHint::Decorated(settings.get_decorated()));
-        glfw.window_hint(glfw::WindowHint::TransparentFramebuffer(settings.get_transparent()));
+        glfw.window_hint(glfw::WindowHint::TransparentFramebuffer(
+            settings.get_transparent(),
+        ));
         // Set sRGB.
         glfw.window_hint(glfw::WindowHint::SRgbCapable(settings.get_srgb()));
         if api >= Api::opengl(3, 2) {
             if cfg!(target_os = "macos") {
                 glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
             }
-            glfw.window_hint(glfw::WindowHint::OpenGlProfile(glfw::OpenGlProfileHint::Core));
+            glfw.window_hint(glfw::WindowHint::OpenGlProfile(
+                glfw::OpenGlProfileHint::Core,
+            ));
         }
         if settings.get_samples() != 0 {
-            glfw.window_hint(glfw::WindowHint::Samples(Some(settings.get_samples() as u32)));
+            glfw.window_hint(glfw::WindowHint::Samples(Some(
+                settings.get_samples() as u32
+            )));
         }
 
         // Create GLFW window.
-        let (mut window, events) = glfw.create_window(
-            settings.get_size().width as u32,
-            settings.get_size().height as u32,
-            &settings.get_title(), glfw::WindowMode::Windowed
-        ).ok_or("Failed to create GLFW window.")?;
+        let (mut window, events) = glfw
+            .create_window(
+                settings.get_size().width as u32,
+                settings.get_size().height as u32,
+                &settings.get_title(),
+                glfw::WindowMode::Windowed,
+            )
+            .ok_or("Failed to create GLFW window.")?;
         window.set_all_polling(true);
         window.make_current();
 
@@ -129,15 +160,25 @@ impl GlfwWindow {
         // Load the OpenGL function pointers.
         gl::load_with(|s| window.get_proc_address(s) as *const _);
 
+        // setup joysticks
+        let mut joysticks = Vec::new();
+        if settings.get_controllers() {
+            for i in JOYSTICKS {
+                joysticks.push(JoystickHelper::new(glfw.get_joystick(i)));
+            }
+        }
+
         Ok(GlfwWindow {
-            window: window,
-            events: events,
-            glfw: glfw,
+            joysticks,
+            window,
+            events,
+            glfw,
             event_queue: VecDeque::new(),
             last_mouse_pos: None,
             title: settings.get_title(),
             exit_on_esc: settings.get_exit_on_esc(),
             automatic_close: settings.get_automatic_close(),
+            joystick_deadzone: 0.0,
         })
     }
 
@@ -145,7 +186,8 @@ impl GlfwWindow {
         for (_, event) in glfw::flush_messages(&self.events) {
             match event {
                 glfw::WindowEvent::Key(glfw::Key::Escape, _, glfw::Action::Press, _)
-                if self.exit_on_esc => {
+                    if self.exit_on_esc =>
+                {
                     self.window.set_should_close(true);
                 }
                 glfw::WindowEvent::Close => {
@@ -158,53 +200,47 @@ impl GlfwWindow {
                     self.event_queue.push_back(Input::Text(ch.to_string()));
                 }
                 glfw::WindowEvent::Key(key, scancode, glfw::Action::Press, _) => {
-                    self.event_queue.push_back(
-                        Input::Button(ButtonArgs {
-                            state: ButtonState::Press,
-                            button: Button::Keyboard(glfw_map_key(key)),
-                            scancode: Some(scancode as i32),
-                        })
-                    );
+                    self.event_queue.push_back(Input::Button(ButtonArgs {
+                        state: ButtonState::Press,
+                        button: Button::Keyboard(glfw_map_key(key)),
+                        scancode: Some(scancode as i32),
+                    }));
                 }
                 glfw::WindowEvent::Key(key, scancode, glfw::Action::Release, _) => {
-                    self.event_queue.push_back(
-                        Input::Button(ButtonArgs {
-                            state: ButtonState::Release,
-                            button: Button::Keyboard(glfw_map_key(key)),
-                            scancode: Some(scancode as i32),
-                        })
-                    );
+                    self.event_queue.push_back(Input::Button(ButtonArgs {
+                        state: ButtonState::Release,
+                        button: Button::Keyboard(glfw_map_key(key)),
+                        scancode: Some(scancode as i32),
+                    }));
                 }
                 glfw::WindowEvent::MouseButton(button, glfw::Action::Press, _) => {
-                    self.event_queue.push_back(
-                        Input::Button(ButtonArgs {
-                            state: ButtonState::Press,
-                            button: Button::Mouse(glfw_map_mouse(button)),
-                            scancode: None,
-                        })
-                    );
+                    self.event_queue.push_back(Input::Button(ButtonArgs {
+                        state: ButtonState::Press,
+                        button: Button::Mouse(glfw_map_mouse(button)),
+                        scancode: None,
+                    }));
                 }
                 glfw::WindowEvent::MouseButton(button, glfw::Action::Release, _) => {
-                    self.event_queue.push_back(
-                        Input::Button(ButtonArgs {
-                            state: ButtonState::Release,
-                            button: Button::Mouse(glfw_map_mouse(button)),
-                            scancode: None,
-                        })
-                    );
+                    self.event_queue.push_back(Input::Button(ButtonArgs {
+                        state: ButtonState::Release,
+                        button: Button::Mouse(glfw_map_mouse(button)),
+                        scancode: None,
+                    }));
                 }
                 glfw::WindowEvent::CursorPos(x, y) => {
-                    self.event_queue.push_back(Input::Move(Motion::MouseCursor([x, y])));
+                    self.event_queue
+                        .push_back(Input::Move(Motion::MouseCursor([x, y])));
                     match self.last_mouse_pos {
-                        Some((lx, ly)) => self.event_queue.push_back(
-                            Input::Move(Motion::MouseRelative([x - lx, y - ly]))
-                        ),
-                        None => ()
+                        Some((lx, ly)) => self
+                            .event_queue
+                            .push_back(Input::Move(Motion::MouseRelative([x - lx, y - ly]))),
+                        None => (),
                     }
                     self.last_mouse_pos = Some((x, y));
                 }
                 glfw::WindowEvent::Scroll(x, y) => {
-                    self.event_queue.push_back(Input::Move(Motion::MouseScroll([x, y])));
+                    self.event_queue
+                        .push_back(Input::Move(Motion::MouseScroll([x, y])));
                 }
                 glfw::WindowEvent::Size(w, h) => {
                     let draw_size = self.draw_size();
@@ -221,11 +257,17 @@ impl GlfwWindow {
                 }
                 glfw::WindowEvent::FileDrop(files) => {
                     for file in files {
-                        self.event_queue.push_back(Input::FileDrag(FileDrag::Drop(file)))
+                        self.event_queue
+                            .push_back(Input::FileDrag(FileDrag::Drop(file)))
                     }
                 }
-                _ => ()
+                _ => (),
             }
+        }
+
+        // println!("checking gamepads");
+        for j in self.joysticks.iter_mut() {
+            j.update(&mut self.event_queue, self.joystick_deadzone);
         }
     }
 
@@ -243,7 +285,8 @@ impl GlfwWindow {
 
     fn wait_event_timeout(&mut self, timeout: Duration) -> Option<Event> {
         if self.event_queue.len() == 0 {
-            let timeout_secs = timeout.as_secs() as f64 + (timeout.subsec_nanos() as f64 / 1_000_000_000.0);
+            let timeout_secs =
+                timeout.as_secs() as f64 + (timeout.subsec_nanos() as f64 / 1_000_000_000.0);
             self.glfw.wait_events_timeout(timeout_secs);
             self.flush_messages();
         }
@@ -277,16 +320,22 @@ impl BuildFromWindowSettings for GlfwWindow {
 impl Window for GlfwWindow {
     fn size(&self) -> Size {
         let (w, h) = self.window.get_size();
-        Size { width: w as f64, height: h as f64 }
+        Size {
+            width: w as f64,
+            height: h as f64,
+        }
     }
 
     fn draw_size(&self) -> Size {
         let (w, h) = self.window.get_framebuffer_size();
-        Size { width: w as f64, height: h as f64 }
+        Size {
+            width: w as f64,
+            height: h as f64,
+        }
     }
 
     fn set_should_close(&mut self, value: bool) {
-       self.window.set_should_close(value);
+        self.window.set_should_close(value);
     }
 
     fn should_close(&self) -> bool {
@@ -339,9 +388,13 @@ impl AdvancedWindow for GlfwWindow {
         self.capture_cursor(value)
     }
 
-    fn show(&mut self) { self.window.show(); }
+    fn show(&mut self) {
+        self.window.show();
+    }
 
-    fn hide(&mut self) { self.window.hide(); }
+    fn hide(&mut self) {
+        self.window.hide();
+    }
 
     fn get_position(&self) -> Option<Position> {
         let (x, y) = self.window.get_pos();
@@ -513,5 +566,111 @@ fn glfw_map_mouse(mouse_button: glfw::MouseButton) -> MouseButton {
         glfw::MouseButton::Button6 => MouseButton::Button6,
         glfw::MouseButton::Button7 => MouseButton::Button7,
         glfw::MouseButton::Button8 => MouseButton::Button8,
+    }
+}
+
+/// helper struct for joystick
+struct JoystickHelper {
+    /// joystick to check
+    joystick: Joystick,
+
+    // states
+    buttons: HashMap<u8, bool>,
+    axes: HashMap<u8, f64>,
+    /// last known connected state
+    connected: bool,
+}
+impl JoystickHelper {
+    fn new(joystick: Joystick) -> Self {
+        Self {
+            joystick,
+            connected: false,
+            buttons: HashMap::new(),
+            axes: HashMap::new(),
+        }
+    }
+
+    fn update(&mut self, event_queue: &mut VecDeque<Input>, deadzone: f64) {
+        match (self.joystick.is_present(), self.connected) {
+            // not connected, and we know its not connected
+            (false, false) => return,
+
+            // was disconnected since last update
+            (false, true) => {
+                self.connected = false;
+                // clear maps to free up memory
+                self.buttons.clear();
+                self.axes.clear();
+                return;
+            }
+
+            // was connected since last update
+            (true, false) => {
+                // insert values
+                self.connected = true;
+
+                // only issue with this approach is a skipped input on the update the controller is connected
+                // i dont think this is a big issue though
+                for (axis, a) in self.joystick.get_axes().iter().enumerate() {
+                    self.axes.insert(axis as u8, *a as f64);
+                }
+                for (button, a) in self.joystick.get_buttons().iter().enumerate() {
+                    self.buttons.insert(button as u8, *a > 1);
+                }
+
+                // exit
+                return;
+            }
+
+            // still connected, nothing to do
+            (true, true) => {}
+        }
+
+        // check axes
+        for (axis, a) in self.joystick.get_axes().iter().enumerate() {
+            let previous = self.axes.get_mut(&(axis as u8)).unwrap();
+            let a = *a as f64;
+
+            if a == *previous || a.abs() < deadzone {
+                // if the value is the same, or within the deadzone, dont do an update
+                continue;
+            } else {
+                // new value, update existing value
+                *previous = a
+            }
+
+            // add change as event
+            event_queue.push_back(Input::Move(Motion::ControllerAxis(
+                ControllerAxisArgs::new(self.joystick.id as u32, axis as u8, a),
+            )));
+        }
+
+        // check buttons
+        for (button, a) in self.joystick.get_buttons().iter().enumerate() {
+            let previous = self.buttons.get_mut(&(button as u8)).unwrap();
+            let pressed = *a > 0;
+
+            if pressed == *previous {
+                // if the value is the same, dont do an update
+                continue;
+            } else {
+                // new value, update existing value
+                *previous = pressed
+            }
+
+            // add change as event
+            event_queue.push_back(Input::Button(ButtonArgs {
+                state: if pressed {
+                    ButtonState::Press
+                } else {
+                    ButtonState::Release
+                },
+                button: Button::Controller(ControllerButton::new(
+                    self.joystick.id as u32,
+                    button as u8,
+                )),
+                scancode: None,
+            }));
+        }
     }
 }


### PR DESCRIPTION
Not sure if this is the best approach but it works and I haven't noticed any decrease in performance.

Tested with the following controllers (so far)

xbox one (windows + linux)
ps4 (windows only so far)
gamecube (via hyperkin adapter) (windows only so far)
logitech attack 3 (windows only so far)

Note: the ps4 and gamecube controllers have wild inputs when not touching the sticks, not sure if this is a glfw or hardware issue, but im leaning on hardware as the xbox one and attack 3 dont have this issue